### PR TITLE
support for empty lists

### DIFF
--- a/rcsb/db/wf/RepoLoadWorkflow.py
+++ b/rcsb/db/wf/RepoLoadWorkflow.py
@@ -464,7 +464,10 @@ class RepoLoadWorkflow(object):
         sublistSize = math.ceil(len(inputList) / nFiles)
 
         # Split the input list into n sublists
-        sublists = [inputList[i: i + sublistSize] for i in range(0, len(inputList), sublistSize)]
+        if sublistSize < 1:
+            sublists = []
+        else:
+            sublists = [inputList[i: i + sublistSize] for i in range(0, len(inputList), sublistSize)]
 
         # Write each sublist to a separate file
         filePathMappingD = {}


### PR DESCRIPTION
A week or two with no new entries would result in the same timestamps for the input list and the out files, which also happens during debugging repeatedly with the same files. Identical timestamps get trimmed out, resulting in an empty list which throws an error unless handled.