### PR TITLE
throw error when timestamp function removes every file

### DIFF
--- a/rcsb/db/wf/RepoLoadWorkflow.py
+++ b/rcsb/db/wf/RepoLoadWorkflow.py
@@ -463,7 +463,7 @@ class RepoLoadWorkflow(object):
 
         # Split the input list into n sublists
         if sublistSize < 1:
-            sublists = []
+            raise ValueError(f"Sublist size {sublistSize}")
         else:
             sublists = [inputList[i: i + sublistSize] for i in range(0, len(inputList), sublistSize)]
 


### PR DESCRIPTION
Incremental update for bcif workflow would be greatly improved with better error handling. If no new entries are found by the split list and timestamp functions, throwing an error would enable the bcif workflow to halt and prevent running downstream tasks unnecessarily.